### PR TITLE
Meeting notes for Jan 25 Office Hours

### DIFF
--- a/meetings/2024/20240125-officehours.md
+++ b/meetings/2024/20240125-officehours.md
@@ -1,0 +1,23 @@
+# 2024-01-25
+
+# Attendance
+* Katherine Druckman (Intel)
+* Tabatha DiDomenico (G-Research)
+* Angie Byron (Aiven)
+* Lori Lorusso
+
+# Agenda
+* Kick-off/intros
+* Making OpenSSF activities digestible to new folks (follow-up from Marketing Committee meeting)
+
+## Making OpenSSF activities digestible to new folks
+There are some new OpenSSF projects being announced. We want to create digestible "1-pagers" for folks new to these projects / the OpenSSF in general on some basic info about each group (Who/What/Where/When/Why/How) that we can get out to the sorts of folks they're looking to join.
+
+Google Form of questions we want to answer available here (this has already been reviewed by DEI committee for inclusive language): https://docs.google.com/forms/d/1C83x5V0lPdbH5oJemWK2-zVels0XGCo64k4_uUkUb4o/viewform?edit_requested=true
+
+Since everyone's time is very limited, for implementation we discussed a member of the committee joining in to one of these projects' standing meetings, and asking for 5 mins at the end to ask the Qs and fill out the form on their behalf. (Ideally recorded, so we get the actual words that people "in the know" use to desribe their pain points / jobs to be done.)
+
+Once we have the information, we can put some templating around them and distribute them as assets.
+
+# Actions
+* @webchick to create a GitHub issue to coordinate this effort.


### PR DESCRIPTION
We kicked off our first office hours today! 🥳

I wasn't 100% sure how to log the minutes from this meeting, so here's a pull request that sticks them in the same meetings/2024 folder as our "regular" meetings, but I can also move them to a sub-folder, etc. too if that's better.

I also proposed here using the naming convention of YYYYMMDD.md because then the files will auto-sort chronologically, but that is a pedantic nerd thing. 🤓